### PR TITLE
Don't overwrite the receiver unless the feed successfully refreshes.

### DIFF
--- a/feedme/feed.go
+++ b/feedme/feed.go
@@ -86,12 +86,11 @@ func (f *FeedInfo) ensureFresh(c appengine.Context) error {
 // stores it's info and articles in the datastore, and removes old articles
 // (those not retrieved on the latest fetch).
 func (f *FeedInfo) refresh(c appengine.Context) error {
-	var articles Articles
-	var err error
-	*f, articles, err = f.readSource(c)
+	fnew, articles, err := f.readSource(c)
 	if err != nil {
 		return err
 	}
+	*f = fnew
 
 	key := datastore.NewKey(c, feedKind, f.Url, 0, nil)
 	err = datastore.RunInTransaction(c, func(c appengine.Context) error {


### PR DESCRIPTION
This fixes a bug where error messages on a failed refresh don't report
the URL of the feed that errored, because the Url field is overwritten
with the zero value.
