### PR TITLE
Return an error when fetching a URL returns an HTTP error.

### DIFF
--- a/feedme/feed.go
+++ b/feedme/feed.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"github.com/velour/feedme/webfeed"
 	"html/template"
+	"net/http"
 	"sort"
 	"strconv"
 	"time"
@@ -273,6 +274,9 @@ func fetchUrl(c appengine.Context, url string) (FeedInfo, Articles, error) {
 	resp, err := urlfetch.Client(c).Get(url)
 	if err != nil {
 		return finfo, nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return finfo, nil, errors.New("HTTP error: " + http.StatusText(resp.StatusCode))
 	}
 	defer resp.Body.Close()
 


### PR DESCRIPTION
The error never makes it back to the use (it's always returned in a
task), but at least it gets logged…

Fixes #66.
