### PR TITLE
Don't force Title Case

### DIFF
--- a/tmplt/articles.html
+++ b/tmplt/articles.html
@@ -56,8 +56,8 @@
 
 {{range .Articles}}
 <a href="{{.Link}}" class="list-group-item">
-	<h4 class="link-title">{{title .Title}}</h4>
-	<p>{{title .OriginTitle}} — <time datetime="{{dateTime .When}}"></time></p>
+	<h4 class="link-title">{{.Title}}</h4>
+	<p>{{.OriginTitle}} — <time datetime="{{dateTime .When}}"></time></p>
 </a>
 {{end}}
 </div>


### PR DESCRIPTION
I am tired of it failing in various ways. E.g. Title with “something in
quotes” → Title With “something In Quotes”. Just go with the source.